### PR TITLE
DrawsanaViewDelegate methods for UserSettings changes; nicer demo; selection tool bug fixes

### DIFF
--- a/Drawsana Demo/Base.lproj/Main.storyboard
+++ b/Drawsana Demo/Base.lproj/Main.storyboard
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" systemVersion="17A277" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="K46-3k-apT">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -9,16 +13,36 @@
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="Drawsana_Demo" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
+                    <navigationItem key="navigationItem" id="MHC-WF-7dm"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="1076" y="132.68365817091455"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="7pJ-5j-kqC">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="K46-3k-apT" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="u0B-uF-XSz">
+                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="BYZ-38-t0r" kind="relationship" relationship="rootViewController" id="t75-Fi-EVI"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="lA0-FB-JOe" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="116" y="-564.46776611694156"/>
         </scene>
     </scenes>
 </document>

--- a/Drawsana Demo/ColorPickerViewController.swift
+++ b/Drawsana Demo/ColorPickerViewController.swift
@@ -1,0 +1,60 @@
+//
+//  ColorPickerViewController.swift
+//  Drawsana Demo
+//
+//  Created by Steve Landey on 8/27/18.
+//  Copyright © 2018 Asana. All rights reserved.
+//
+
+import UIKit
+
+protocol ColorPickerViewControllerDelegate: AnyObject {
+  func colorPickerViewControllerDidPick(colorIndex: Int, color: UIColor?, identifier: String)
+}
+
+class ColorPickerViewController: UIViewController {
+  let colors: [UIColor?]
+  weak var delegate: ColorPickerViewControllerDelegate?
+  var identifier: String
+
+  init(identifier: String, colors: [UIColor?], delegate: ColorPickerViewControllerDelegate) {
+    self.identifier = identifier
+    self.colors = colors
+    self.delegate = delegate
+    super.init(nibName: nil, bundle: nil)
+    preferredContentSize = CGSize(width: 44, height: colors.count * (44 + 10) + 10)
+  }
+
+  required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  override func loadView() {
+    let stackView = UIStackView(arrangedSubviews: colors.enumerated().map({ (i, color) in
+      let button = UIButton()
+      button.tag = i
+      button.translatesAutoresizingMaskIntoConstraints = false
+      button.addTarget(self, action: #selector(ColorPickerViewController.setColor(button:)), for: .touchUpInside)
+      button.backgroundColor = color == nil ? .black : color
+      if color == nil {
+        button.setTitle("✕", for: .normal)
+      }
+
+      NSLayoutConstraint.activate([
+        button.widthAnchor.constraint(equalToConstant: 44),
+        button.heightAnchor.constraint(equalToConstant: 44),
+      ])
+      return button
+    }))
+
+    stackView.axis = .vertical
+    stackView.distribution = .equalSpacing
+    stackView.alignment = .fill
+    self.view = stackView
+  }
+
+  @objc private func setColor(button: UIButton) {
+    delegate?.colorPickerViewControllerDidPick(
+      colorIndex: button.tag, color: colors[button.tag], identifier: identifier)
+  }
+}

--- a/Drawsana Demo/ToolPickerViewController.swift
+++ b/Drawsana Demo/ToolPickerViewController.swift
@@ -1,0 +1,57 @@
+//
+//  ToolPickerViewController.swift
+//  Drawsana Demo
+//
+//  Created by Steve Landey on 8/27/18.
+//  Copyright © 2018 Asana. All rights reserved.
+//
+
+import Drawsana
+import UIKit
+
+protocol ToolPickerViewControllerDelegate: AnyObject {
+  func toolPickerViewControllerDidPick(tool: DrawingTool)
+}
+
+class ToolPickerViewController: UIViewController {
+  let tools: [DrawingTool]
+  weak var delegate: ToolPickerViewControllerDelegate?
+
+  init(tools: [DrawingTool], delegate: ToolPickerViewControllerDelegate) {
+    self.tools = tools
+    self.delegate = delegate
+    super.init(nibName: nil, bundle: nil)
+    preferredContentSize = CGSize(width: 90, height: tools.count * (44 + 10) + 10)
+  }
+
+  required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  override func loadView() {
+    let stackView = UIStackView(arrangedSubviews: tools.enumerated().map({ (i, tool) in
+      let button = UIButton()
+      button.tag = i
+      button.translatesAutoresizingMaskIntoConstraints = false
+      button.addTarget(self, action: #selector(ToolPickerViewController.setTool(button:)), for: .touchUpInside)
+      button.setTitle(tool.name, for: .normal)
+      button.setTitleColor(.blue, for: .normal)
+
+      NSLayoutConstraint.activate([
+        button.widthAnchor.constraint(equalToConstant: 90),
+        button.heightAnchor.constraint(equalToConstant: 44),
+        ])
+      return button
+    }))
+
+    stackView.axis = .vertical
+    stackView.distribution = .equalSpacing
+    stackView.alignment = .fill
+    self.view = stackView
+  }
+
+  @objc private func setTool(button: UIButton) {
+    delegate?.toolPickerViewControllerDidPick(tool: tools[button.tag])
+  }
+}
+

--- a/Drawsana.xcodeproj/project.pbxproj
+++ b/Drawsana.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		3706B15C211BA07F00D41622 /* KeyedDecodingContainer+DrawsanaExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3706B15B211BA07F00D41622 /* KeyedDecodingContainer+DrawsanaExtensions.swift */; };
 		3706B15E211CF29500D41622 /* DrawingToolForShapeWithTwoPoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3706B15D211CF29500D41622 /* DrawingToolForShapeWithTwoPoints.swift */; };
 		371BE7D02123643100861596 /* ImmediatePanGestureRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371BE7CF2123643100861596 /* ImmediatePanGestureRecognizer.swift */; };
+		372093CF21345862001A906E /* ColorPickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 372093CE21345862001A906E /* ColorPickerViewController.swift */; };
 		37362D5C21151684003E5ACA /* TextShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37362D5B21151684003E5ACA /* TextShape.swift */; };
 		37362D5E2118D8A3003E5ACA /* ToolSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37362D5D2118D8A3003E5ACA /* ToolSettings.swift */; };
 		37362D602118E46F003E5ACA /* DrawingOperationStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37362D5F2118E46F003E5ACA /* DrawingOperationStack.swift */; };
@@ -85,6 +86,7 @@
 		3706B15B211BA07F00D41622 /* KeyedDecodingContainer+DrawsanaExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyedDecodingContainer+DrawsanaExtensions.swift"; sourceTree = "<group>"; };
 		3706B15D211CF29500D41622 /* DrawingToolForShapeWithTwoPoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawingToolForShapeWithTwoPoints.swift; sourceTree = "<group>"; };
 		371BE7CF2123643100861596 /* ImmediatePanGestureRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImmediatePanGestureRecognizer.swift; sourceTree = "<group>"; };
+		372093CE21345862001A906E /* ColorPickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorPickerViewController.swift; sourceTree = "<group>"; };
 		37362D5B21151684003E5ACA /* TextShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextShape.swift; sourceTree = "<group>"; };
 		37362D5D2118D8A3003E5ACA /* ToolSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolSettings.swift; sourceTree = "<group>"; };
 		37362D5F2118E46F003E5ACA /* DrawingOperationStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawingOperationStack.swift; sourceTree = "<group>"; };
@@ -302,6 +304,7 @@
 			children = (
 				37EB4EFC21064A5E00E10461 /* AppDelegate.swift */,
 				37EB4EFE21064A5E00E10461 /* ViewController.swift */,
+				372093CE21345862001A906E /* ColorPickerViewController.swift */,
 				37EB4F0021064A5E00E10461 /* Main.storyboard */,
 				37EB4F0321064A6000E10461 /* Assets.xcassets */,
 				37EB4F0521064A6000E10461 /* LaunchScreen.storyboard */,
@@ -500,6 +503,7 @@
 			files = (
 				37EB4EFF21064A5E00E10461 /* ViewController.swift in Sources */,
 				37EB4EFD21064A5E00E10461 /* AppDelegate.swift in Sources */,
+				372093CF21345862001A906E /* ColorPickerViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Drawsana.xcodeproj/project.pbxproj
+++ b/Drawsana.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		3706B15E211CF29500D41622 /* DrawingToolForShapeWithTwoPoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3706B15D211CF29500D41622 /* DrawingToolForShapeWithTwoPoints.swift */; };
 		371BE7D02123643100861596 /* ImmediatePanGestureRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371BE7CF2123643100861596 /* ImmediatePanGestureRecognizer.swift */; };
 		372093CF21345862001A906E /* ColorPickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 372093CE21345862001A906E /* ColorPickerViewController.swift */; };
+		372093D121345DB7001A906E /* ToolPickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 372093D021345DB7001A906E /* ToolPickerViewController.swift */; };
 		37362D5C21151684003E5ACA /* TextShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37362D5B21151684003E5ACA /* TextShape.swift */; };
 		37362D5E2118D8A3003E5ACA /* ToolSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37362D5D2118D8A3003E5ACA /* ToolSettings.swift */; };
 		37362D602118E46F003E5ACA /* DrawingOperationStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37362D5F2118E46F003E5ACA /* DrawingOperationStack.swift */; };
@@ -87,6 +88,7 @@
 		3706B15D211CF29500D41622 /* DrawingToolForShapeWithTwoPoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawingToolForShapeWithTwoPoints.swift; sourceTree = "<group>"; };
 		371BE7CF2123643100861596 /* ImmediatePanGestureRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImmediatePanGestureRecognizer.swift; sourceTree = "<group>"; };
 		372093CE21345862001A906E /* ColorPickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorPickerViewController.swift; sourceTree = "<group>"; };
+		372093D021345DB7001A906E /* ToolPickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolPickerViewController.swift; sourceTree = "<group>"; };
 		37362D5B21151684003E5ACA /* TextShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextShape.swift; sourceTree = "<group>"; };
 		37362D5D2118D8A3003E5ACA /* ToolSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolSettings.swift; sourceTree = "<group>"; };
 		37362D5F2118E46F003E5ACA /* DrawingOperationStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawingOperationStack.swift; sourceTree = "<group>"; };
@@ -305,6 +307,7 @@
 				37EB4EFC21064A5E00E10461 /* AppDelegate.swift */,
 				37EB4EFE21064A5E00E10461 /* ViewController.swift */,
 				372093CE21345862001A906E /* ColorPickerViewController.swift */,
+				372093D021345DB7001A906E /* ToolPickerViewController.swift */,
 				37EB4F0021064A5E00E10461 /* Main.storyboard */,
 				37EB4F0321064A6000E10461 /* Assets.xcassets */,
 				37EB4F0521064A6000E10461 /* LaunchScreen.storyboard */,
@@ -501,6 +504,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				372093D121345DB7001A906E /* ToolPickerViewController.swift in Sources */,
 				37EB4EFF21064A5E00E10461 /* ViewController.swift in Sources */,
 				37EB4EFD21064A5E00E10461 /* AppDelegate.swift in Sources */,
 				372093CF21345862001A906E /* ColorPickerViewController.swift in Sources */,

--- a/Drawsana/DrawsanaView.swift
+++ b/Drawsana/DrawsanaView.swift
@@ -8,6 +8,8 @@
 
 import UIKit
 
+public let DRAWSANA_VERSION = "1.0"
+
 /// Set yourself as the `DrawsanaView`'s delegate to be notified when the active
 /// tool changes.
 public protocol DrawsanaViewDelegate: AnyObject {

--- a/Drawsana/DrawsanaView.swift
+++ b/Drawsana/DrawsanaView.swift
@@ -14,6 +14,11 @@ public protocol DrawsanaViewDelegate: AnyObject {
   func drawsanaView(_ drawsanaView: DrawsanaView, didSwitchTo tool: DrawingTool)
   func drawsanaView(_ drawsanaView: DrawsanaView, didStartDragWith tool: DrawingTool)
   func drawsanaView(_ drawsanaView: DrawsanaView, didEndDragWith tool: DrawingTool)
+  func drawsanaView(_ drawsanaView: DrawsanaView, didChangeStrokeColor strokeColor: UIColor?)
+  func drawsanaView(_ drawsanaView: DrawsanaView, didChangeFillColor fillColor: UIColor?)
+  func drawsanaView(_ drawsanaView: DrawsanaView, didChangeStrokeWidth strokeWidth: CGFloat)
+  func drawsanaView(_ drawsanaView: DrawsanaView, didChangeFontName fontName: String)
+  func drawsanaView(_ drawsanaView: DrawsanaView, didChangeFontSize fontSize: CGFloat)
 }
 
 /**
@@ -31,7 +36,7 @@ public class DrawsanaView: UIView {
   /// active tool and applied to new shapes.
   public let userSettings = UserSettings(
     strokeColor: .blue,
-    fillColor: nil,
+    fillColor: .yellow,
     strokeWidth: 20,
     fontName: "Helvetica Neue",
     fontSize: 24)
@@ -433,26 +438,31 @@ extension DrawsanaView: UserSettingsDelegate {
   func userSettings(_ userSettings: UserSettings, didChangeStrokeColor strokeColor: UIColor?) {
     tool?.apply(context: toolOperationContext, userSettings: userSettings)
     applyToolSettingsChanges()
+    delegate?.drawsanaView(self, didChangeStrokeColor: strokeColor)
   }
 
   func userSettings(_ userSettings: UserSettings, didChangeFillColor fillColor: UIColor?) {
     tool?.apply(context: toolOperationContext, userSettings: userSettings)
     applyToolSettingsChanges()
+    delegate?.drawsanaView(self, didChangeFillColor: fillColor)
   }
 
   func userSettings(_ userSettings: UserSettings, didChangeStrokeWidth strokeWidth: CGFloat) {
     tool?.apply(context: toolOperationContext, userSettings: userSettings)
     applyToolSettingsChanges()
+    delegate?.drawsanaView(self, didChangeStrokeWidth: strokeWidth)
   }
 
   func userSettings(_ userSettings: UserSettings, didChangeFontName fontName: String) {
     tool?.apply(context: toolOperationContext, userSettings: userSettings)
     applyToolSettingsChanges()
+    delegate?.drawsanaView(self, didChangeFontName: fontName)
   }
 
   func userSettings(_ userSettings: UserSettings, didChangeFontSize fontSize: CGFloat) {
     tool?.apply(context: toolOperationContext, userSettings: userSettings)
     applyToolSettingsChanges()
+    delegate?.drawsanaView(self, didChangeFontSize: fontSize)
   }
 }
 

--- a/Drawsana/Tools/Implementations/PenTool_EraserTool.swift
+++ b/Drawsana/Tools/Implementations/PenTool_EraserTool.swift
@@ -87,7 +87,7 @@ public class PenTool: DrawingTool {
       self.shapeInProgressBuffer?.draw(at: .zero)
       self.shapeInProgress?.renderLatestSegment(in: $0)
     }
-    shapeInProgressBuffer?.draw(at: .zero, blendMode: .overlay, alpha: alpha)
+    shapeInProgressBuffer?.draw(at: .zero, blendMode: .normal, alpha: alpha)
   }
 }
 


### PR DESCRIPTION
I started this change by just trying to make the demo a little bit nicer:

* Use popovers to pick colors and tools, rather than cycling through a list. This change should make it more obvious what the library's features are when people try it.
* Wrap the root view controller in a navigation controller so the top looks a little nicer

Then I discovered a bug: if you make a shape, make another shape with different colors, and select the original shape, it would apply the new colors to the original shape. We don't want this; we only want the selected shape to be changed if the user makes a new color or stroke width selection. So the selection tool now accounts for this.

While doing all of that, I got annoyed by the lack of granular delegate methods for different user settings, so I added them. It should be more obvious now how to implement a correct UI.