### PR TITLE
TextShapeEditingView has completely customizable controls

### DIFF
--- a/Drawsana Demo/ViewController.swift
+++ b/Drawsana Demo/ViewController.swift
@@ -342,6 +342,7 @@ extension ViewController: TextToolDelegate {
   }
 
   func textToolWillUseEditingView(_ editingView: TextShapeEditingView) {
+    editingView.addStandardControls()
     for view in [editingView.deleteControlView, editingView.resizeAndRotateControlView] {
       view.backgroundColor = .black
       view.layer.cornerRadius = 6


### PR DESCRIPTION
The text tool no longer forces you into a top-left, top-right, bottom-right configuration for the handles that let you delete, resize/rotate, and wrap text. It's easy to use the default: either don't set the text tool delegate, or call `editingView.addStandardControls()`.

Asana's mobile designer just gave me 3+ options for how to do text controls, so I thought it best to just support all of them upstream and do the customization in our app, which is the point anyway. :-)