### PR TITLE
Tweak API to allow text controls to be scaled as the transform changes

### DIFF
--- a/Drawsana/Shapes/ShapeTransform.swift
+++ b/Drawsana/Shapes/ShapeTransform.swift
@@ -13,11 +13,11 @@ import CoreGraphics
  rotate, scale) that can be applied to `ShapeWithTransform`.
  */
 public struct ShapeTransform: Codable {
-  var translation: CGPoint
-  var rotation: CGFloat
-  var scale: CGFloat
+  public var translation: CGPoint
+  public var rotation: CGFloat
+  public var scale: CGFloat
 
-  static let identity = ShapeTransform(translation: .zero, rotation: 0, scale: 1)
+  public static let identity = ShapeTransform(translation: .zero, rotation: 0, scale: 1)
 }
 
 extension ShapeTransform {

--- a/Drawsana/Tools/Implementations/Text tool/TextShapeEditingView.swift
+++ b/Drawsana/Tools/Implementations/Text tool/TextShapeEditingView.swift
@@ -29,8 +29,8 @@ public class TextShapeEditingView: UIView {
   }
 
   public struct Control {
-    let view: UIView
-    let dragActionType: DragActionType
+    public let view: UIView
+    public let dragActionType: DragActionType
   }
 
   public private(set) var controls = [Control]()

--- a/Drawsana/Tools/Implementations/Text tool/TextTool.swift
+++ b/Drawsana/Tools/Implementations/Text tool/TextTool.swift
@@ -25,6 +25,12 @@ public protocol TextToolDelegate: AnyObject {
   /// call `editingView.addStandardControls()` to add the delete button and the
   /// two resize handles.
   func textToolWillUseEditingView(_ editingView: TextShapeEditingView)
+
+  /// The user has changed the transform of the selected shape. You may leave
+  /// this method empty, but unless you want your text controls to scale with
+  /// the text, you'll need to do some math and apply some inverse scaling
+  /// transforms here.
+  func textToolDidUpdateEditingViewTransform(_ editingView: TextShapeEditingView, transform: ShapeTransform)
 }
 
 public class TextTool: NSObject, DrawingTool {
@@ -242,6 +248,8 @@ public class TextTool: NSObject, DrawingTool {
       translationX: -shape.boundingRect.size.width / 2,
       y: -shape.boundingRect.size.height / 2
     ).concatenating(shape.transform.affineTransform)
+
+    delegate?.textToolDidUpdateEditingViewTransform(editingView, transform: shape.transform)
 
     editingView.setNeedsLayout()
     editingView.layoutIfNeeded()


### PR DESCRIPTION
Before this change, it was impossible to have the text drag handles remain a constant size as the text scale was changed.

* Mark some important things as public: `ShapeTransform.*`, `TextShapeEditingView.Control.*`
* New delegate method `textToolDidUpdateEditingViewTransform`
* Example code to demonstrate how to use it