### PR TITLE
Added a scale parameter to the renderImage class with the default value of 1

### DIFF
--- a/Drawsana/DrawsanaView.swift
+++ b/Drawsana/DrawsanaView.swift
@@ -223,10 +223,10 @@ public class DrawsanaView: UIView {
 
   /// Render the drawing on top of an image, using that image's size. Shapes are
   /// re-scaled to match the resolution of the target without artifacts.
-  public func render(over image: UIImage?) -> UIImage? {
+    public func render(over image: UIImage?, scale:CGFloat = 0.0) -> UIImage? {
     let size = image?.size ?? drawing.size
-    let shapesImage = render(size: size)
-    return DrawsanaUtilities.renderImage(size: size) { (context: CGContext) -> Void in
+    let shapesImage = render(size: size, scale: scale)
+    return DrawsanaUtilities.renderImage(size: size, scale: scale) { (context: CGContext) -> Void in
       image?.draw(at: .zero)
       shapesImage?.draw(at: .zero)
     }
@@ -234,9 +234,9 @@ public class DrawsanaView: UIView {
 
   /// Render the drawing. If you pass a size, shapes are re-scaled to be full
   /// resolution at that size, otherwise the view size is used.
-  public func render(size: CGSize? = nil) -> UIImage? {
+    public func render(size: CGSize? = nil, scale:CGFloat = 0.0) -> UIImage? {
     let size = size ?? drawing.size
-    return DrawsanaUtilities.renderImage(size: size) { (context: CGContext) -> Void in
+        return DrawsanaUtilities.renderImage(size: size, scale:scale) { (context: CGContext) -> Void in
       context.saveGState()
       context.scaleBy(
         x: size.width / self.drawing.size.width,

--- a/Drawsana/DrawsanaView.swift
+++ b/Drawsana/DrawsanaView.swift
@@ -223,6 +223,9 @@ public class DrawsanaView: UIView {
 
   /// Render the drawing on top of an image, using that image's size. Shapes are
   /// re-scaled to match the resolution of the target without artifacts.
+  /// The scale parameter defines wether image is rendered at the device's native resolution (scale = 0.0)
+  /// or to scale it to the image size (scale 1.0). Use scale = 0.0 when rendering to display on screen and
+  /// 1.0 if you are saving the image to a file
     public func render(over image: UIImage?, scale:CGFloat = 0.0) -> UIImage? {
     let size = image?.size ?? drawing.size
     let shapesImage = render(size: size, scale: scale)

--- a/Drawsana/Helpers/DrawsanaUtilities.swift
+++ b/Drawsana/Helpers/DrawsanaUtilities.swift
@@ -26,7 +26,7 @@ class DrawsanaUtilities {
   }
 
   /// Render an image using CoreGraphics
-    class func renderImage(size: CGSize, scale:CGFloat = 1.0, _ code: (CGContext) -> Void) -> UIImage? {
+    class func renderImage(size: CGSize, scale:CGFloat = 0.0, _ code: (CGContext) -> Void) -> UIImage? {
     UIGraphicsBeginImageContextWithOptions(size, false, scale)
     guard let context = UIGraphicsGetCurrentContext() else {
       UIGraphicsEndImageContext()

--- a/Drawsana/Helpers/DrawsanaUtilities.swift
+++ b/Drawsana/Helpers/DrawsanaUtilities.swift
@@ -26,8 +26,8 @@ class DrawsanaUtilities {
   }
 
   /// Render an image using CoreGraphics
-  class func renderImage(size: CGSize, _ code: (CGContext) -> Void) -> UIImage? {
-    UIGraphicsBeginImageContextWithOptions(size, false, 0)
+    class func renderImage(size: CGSize, scale:CGFloat = 1.0, _ code: (CGContext) -> Void) -> UIImage? {
+    UIGraphicsBeginImageContextWithOptions(size, false, scale)
     guard let context = UIGraphicsGetCurrentContext() else {
       UIGraphicsEndImageContext()
       return nil


### PR DESCRIPTION
Added a scale parameter to the renderImage class with the default value of 1. This is to fix a problem where the output image was rendering way bigger than the original image. The reason is that if we pass 0 as the scale on the method UIGraphicsBeginImageContextWithOptions the output is set to the scale factor of the device’s main screen creating images that may be 2x or 3x bigger than the original (depending on the device used)