### PR TITLE
Fix many, many bugs

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -37,28 +37,37 @@ custom_categories:
   - ShapeWithStandardState
   - ShapeWithStrokeState
   - ShapeWithTwoPoints
+  - ShapeWithThreePoints
 - name: Tool building blocks
   children:
   - DrawingTool
   - DrawingToolForShapeWithTwoPoints
+  - DrawingToolForShapeWithThreePoints
 - name: Shape implementations
   children:
+  - AngleShape
   - EllipseShape
   - LineShape
+  - NgonShape
   - PenShape
   - PenLineSegment
   - RectShape
+  - StarShape
   - TextShape
 - name: Tool implementations
   children:
+  - AngleTool
   - ArrowTool
   - EllipseTool
   - EraserTool
   - LineTool
   - PenTool
+  - PentagonTool
   - RectTool
   - SelectionTool
   - SelectionToolDelegate
+  - StarTool
   - TextTool
   - TextToolDelegate
   - TextShapeEditingView
+  - TriangleTool

--- a/Drawsana Demo/ViewController.swift
+++ b/Drawsana Demo/ViewController.swift
@@ -186,6 +186,9 @@ class ViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
 
+    // Better error reporting in dev
+    Drawing.debugSerialization = true
+
     navigationItem.rightBarButtonItem = viewFinalImageButton
 
     // Set initial tool to whatever `toolIndex` says
@@ -259,9 +262,14 @@ class ViewController: UIViewController {
 
   @objc private func reload(_ sender: Any?) {
     print("Serializing/deserializing...")
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
+    let jsonData = try! encoder.encode(drawingView.drawing)
+    print(String(data: jsonData, encoding: .utf8)!)
     drawingView.drawing = try! JSONDecoder().decode(
       Drawing.self,
-      from: try! JSONEncoder().encode(drawingView.drawing))
+      from: jsonData)
+    print(drawingView.drawing.shapes)
     print("Done")
   }
 

--- a/Drawsana Demo/ViewController.swift
+++ b/Drawsana Demo/ViewController.swift
@@ -51,6 +51,7 @@ class ViewController: UIViewController {
   let strokeColorButton = UIButton()
   let fillColorButton = UIButton()
   let strokeWidthButton = UIButton()
+  let reloadButton = UIButton()
   lazy var toolbarStackView = {
     return UIStackView(arrangedSubviews: [
       undoButton,
@@ -58,6 +59,7 @@ class ViewController: UIViewController {
       strokeColorButton,
       fillColorButton,
       strokeWidthButton,
+      reloadButton,
       toolButton,
     ])
   }()
@@ -123,6 +125,12 @@ class ViewController: UIViewController {
     strokeWidthButton.addTarget(self, action: #selector(ViewController.cycleStrokeWidth(_:)), for: .touchUpInside)
     strokeWidthButton.layer.borderColor = UIColor.white.cgColor
     strokeWidthButton.layer.borderWidth = 0.5
+
+    reloadButton.translatesAutoresizingMaskIntoConstraints = false
+    reloadButton.addTarget(self, action: #selector(ViewController.reload(_:)), for: .touchUpInside)
+    reloadButton.layer.borderColor = UIColor.white.cgColor
+    reloadButton.layer.borderWidth = 0.5
+    reloadButton.setTitle("🔁", for: .normal)
 
     toolbarStackView.translatesAutoresizingMaskIntoConstraints = false
     toolbarStackView.axis = .horizontal
@@ -247,6 +255,14 @@ class ViewController: UIViewController {
   @objc private func cycleStrokeWidth(_ sender: Any?) {
     strokeWidthIndex = (strokeWidthIndex + 1) % strokeWidths.count
     drawingView.userSettings.strokeWidth = strokeWidths[strokeWidthIndex]
+  }
+
+  @objc private func reload(_ sender: Any?) {
+    print("Serializing/deserializing...")
+    drawingView.drawing = try! JSONDecoder().decode(
+      Drawing.self,
+      from: try! JSONEncoder().encode(drawingView.drawing))
+    print("Done")
   }
 
   /// Update button states to reflect undo stack

--- a/Drawsana Tests/DrawsanaTests.swift
+++ b/Drawsana Tests/DrawsanaTests.swift
@@ -20,9 +20,9 @@ let defaultTransform = ShapeTransform(
   rotation: 4,
   scale: 5)
 
-class LineShapeTests: XCTestCase {
+struct DefaultShapes {
 
-  var defaultShape: LineShape {
+  static var line: LineShape {
     let shape = LineShape()
     shape.id = "shape"
     shape.a = CGPoint(x: 1, y: 1)
@@ -38,8 +38,117 @@ class LineShapeTests: XCTestCase {
     return shape
   }
 
+  static var rect: RectShape {
+    let shape = RectShape()
+    shape.id = "shape"
+    shape.a = CGPoint(x: 1, y: 1)
+    shape.b = CGPoint(x: 2, y: 2)
+    shape.capStyle = .butt
+    shape.dashLengths = [1, 1]
+    shape.dashPhase = 1
+    shape.fillColor = .yellow
+    shape.joinStyle = .bevel
+    shape.strokeColor = .red
+    shape.strokeWidth = 10
+    shape.transform = defaultTransform
+    return shape
+  }
+
+  static var text: TextShape {
+    let shape = TextShape()
+    shape.id = "shape"
+    shape.explicitWidth = 100
+    shape.fontName = "Helvetica Neue"
+    shape.fontSize = 12
+    shape.text = "xyzzy"
+    shape.fillColor = .yellow
+    shape.transform = defaultTransform
+    return shape
+  }
+
+  static var ellipse: EllipseShape {
+    let shape = EllipseShape()
+    shape.id = "shape"
+    shape.a = CGPoint(x: 1, y: 1)
+    shape.b = CGPoint(x: 2, y: 2)
+    shape.capStyle = .butt
+    shape.dashLengths = [1, 1]
+    shape.dashPhase = 1
+    shape.fillColor = .yellow
+    shape.joinStyle = .bevel
+    shape.strokeColor = .red
+    shape.strokeWidth = 10
+    shape.transform = defaultTransform
+    return shape
+  }
+
+  static var angle: AngleShape {
+    let shape = AngleShape()
+    shape.id = "shape"
+    shape.a = CGPoint(x: 1, y: 1)
+    shape.b = CGPoint(x: 2, y: 2)
+    shape.c = CGPoint(x: 20, y: 20)
+    shape.capStyle = .butt
+    shape.dashLengths = [1, 1]
+    shape.dashPhase = 1
+    shape.joinStyle = .bevel
+    shape.strokeColor = .red
+    shape.strokeWidth = 10
+    shape.transform = defaultTransform
+    return shape
+  }
+
+  static var star: StarShape {
+    let shape = StarShape()
+    shape.id = "shape"
+    shape.a = CGPoint(x: 1, y: 1)
+    shape.b = CGPoint(x: 2, y: 2)
+    shape.capStyle = .butt
+    shape.dashLengths = [1, 1]
+    shape.dashPhase = 1
+    shape.fillColor = .yellow
+    shape.joinStyle = .bevel
+    shape.strokeColor = .red
+    shape.strokeWidth = 10
+    shape.transform = defaultTransform
+    return shape
+  }
+
+  static var ngon: NgonShape {
+    let shape = NgonShape(8)
+    shape.id = "shape"
+    shape.a = CGPoint(x: 1, y: 1)
+    shape.b = CGPoint(x: 2, y: 2)
+    shape.capStyle = .butt
+    shape.dashLengths = [1, 1]
+    shape.dashPhase = 1
+    shape.fillColor = .yellow
+    shape.joinStyle = .bevel
+    shape.strokeColor = .red
+    shape.strokeWidth = 10
+    shape.transform = defaultTransform
+    return shape
+  }
+
+  static var eraser: PenShape {
+    let shape = PenShape()
+    shape.id = "shape"
+    shape.start = CGPoint(x: 1, y: 1)
+    shape.add(segment: PenLineSegment(a: CGPoint(x: 1, y: 1), b: CGPoint(x: 2, y: 2), width: 1))
+    shape.add(segment: PenLineSegment(a: CGPoint(x: 2, y: 2), b: CGPoint(x: 3, y: 3), width: 2))
+    shape.isFinished = true
+    shape.strokeColor = .red
+    shape.strokeWidth = 10
+    shape.isEraser = true
+    return shape
+  }
+
+}
+
+class LineShapeTests: XCTestCase {
+
   func testSerialize() {
-    let json = getJSON(defaultShape)
+    let json = getJSON(DefaultShapes.line)
     let decodedShape = try! JSONDecoder().decode(LineShape.self, from: json)
     XCTAssertEqual(decodedShape.id, "shape")
     XCTAssertEqual(decodedShape.a, CGPoint(x: 1, y: 1))
@@ -59,24 +168,8 @@ class LineShapeTests: XCTestCase {
 
 class RectShapeTests: XCTestCase {
 
-  var defaultShape: RectShape {
-    let shape = RectShape()
-    shape.id = "shape"
-    shape.a = CGPoint(x: 1, y: 1)
-    shape.b = CGPoint(x: 2, y: 2)
-    shape.capStyle = .butt
-    shape.dashLengths = [1, 1]
-    shape.dashPhase = 1
-    shape.fillColor = .yellow
-    shape.joinStyle = .bevel
-    shape.strokeColor = .red
-    shape.strokeWidth = 10
-    shape.transform = defaultTransform
-    return shape
-  }
-
   func testSerialize() {
-    let json = getJSON(defaultShape)
+    let json = getJSON(DefaultShapes.rect)
     let decodedShape = try! JSONDecoder().decode(RectShape.self, from: json)
     XCTAssertEqual(decodedShape.id, "shape")
     XCTAssertEqual(decodedShape.a, CGPoint(x: 1, y: 1))
@@ -95,20 +188,8 @@ class RectShapeTests: XCTestCase {
 
 class TextShapeTests: XCTestCase {
 
-  var defaultShape: TextShape {
-    let shape = TextShape()
-    shape.id = "shape"
-    shape.explicitWidth = 100
-    shape.fontName = "Helvetica Neue"
-    shape.fontSize = 12
-    shape.text = "xyzzy"
-    shape.fillColor = .yellow
-    shape.transform = defaultTransform
-    return shape
-  }
-
   func testSerialize() {
-    let json = getJSON(defaultShape)
+    let json = getJSON(DefaultShapes.text)
     let decodedShape = try! JSONDecoder().decode(TextShape.self, from: json)
     XCTAssertEqual(decodedShape.id, "shape")
     XCTAssertEqual(decodedShape.explicitWidth, 100)
@@ -123,24 +204,8 @@ class TextShapeTests: XCTestCase {
 
 class EllipseShapeTests: XCTestCase {
 
-  var defaultShape: EllipseShape {
-    let shape = EllipseShape()
-    shape.id = "shape"
-    shape.a = CGPoint(x: 1, y: 1)
-    shape.b = CGPoint(x: 2, y: 2)
-    shape.capStyle = .butt
-    shape.dashLengths = [1, 1]
-    shape.dashPhase = 1
-    shape.fillColor = .yellow
-    shape.joinStyle = .bevel
-    shape.strokeColor = .red
-    shape.strokeWidth = 10
-    shape.transform = defaultTransform
-    return shape
-  }
-
   func testSerialize() {
-    let json = getJSON(defaultShape)
+    let json = getJSON(DefaultShapes.ellipse)
     let decodedShape = try! JSONDecoder().decode(EllipseShape.self, from: json)
     XCTAssertEqual(decodedShape.id, "shape")
     XCTAssertEqual(decodedShape.a, CGPoint(x: 1, y: 1))
@@ -159,24 +224,8 @@ class EllipseShapeTests: XCTestCase {
 
 class AngleShapeTests: XCTestCase {
 
-  var defaultShape: AngleShape {
-    let shape = AngleShape()
-    shape.id = "shape"
-    shape.a = CGPoint(x: 1, y: 1)
-    shape.b = CGPoint(x: 2, y: 2)
-    shape.c = CGPoint(x: 20, y: 20)
-    shape.capStyle = .butt
-    shape.dashLengths = [1, 1]
-    shape.dashPhase = 1
-    shape.joinStyle = .bevel
-    shape.strokeColor = .red
-    shape.strokeWidth = 10
-    shape.transform = defaultTransform
-    return shape
-  }
-
   func testSerialize() {
-    let json = getJSON(defaultShape)
+    let json = getJSON(DefaultShapes.angle)
     let decodedShape = try! JSONDecoder().decode(AngleShape.self, from: json)
     XCTAssertEqual(decodedShape.id, "shape")
     XCTAssertEqual(decodedShape.a, CGPoint(x: 1, y: 1))
@@ -195,24 +244,8 @@ class AngleShapeTests: XCTestCase {
 
 class StarShapeTests: XCTestCase {
 
-  var defaultShape: StarShape {
-    let shape = StarShape()
-    shape.id = "shape"
-    shape.a = CGPoint(x: 1, y: 1)
-    shape.b = CGPoint(x: 2, y: 2)
-    shape.capStyle = .butt
-    shape.dashLengths = [1, 1]
-    shape.dashPhase = 1
-    shape.fillColor = .yellow
-    shape.joinStyle = .bevel
-    shape.strokeColor = .red
-    shape.strokeWidth = 10
-    shape.transform = defaultTransform
-    return shape
-  }
-
   func testSerialize() {
-    let json = getJSON(defaultShape)
+    let json = getJSON(DefaultShapes.star)
     let decodedShape = try! JSONDecoder().decode(StarShape.self, from: json)
     XCTAssertEqual(decodedShape.id, "shape")
     XCTAssertEqual(decodedShape.a, CGPoint(x: 1, y: 1))
@@ -231,24 +264,8 @@ class StarShapeTests: XCTestCase {
 
 class NgonShapeTests: XCTestCase {
 
-  var defaultShape: NgonShape {
-    let shape = NgonShape(8)
-    shape.id = "shape"
-    shape.a = CGPoint(x: 1, y: 1)
-    shape.b = CGPoint(x: 2, y: 2)
-    shape.capStyle = .butt
-    shape.dashLengths = [1, 1]
-    shape.dashPhase = 1
-    shape.fillColor = .yellow
-    shape.joinStyle = .bevel
-    shape.strokeColor = .red
-    shape.strokeWidth = 10
-    shape.transform = defaultTransform
-    return shape
-  }
-
   func testSerialize() {
-    let json = getJSON(defaultShape)
+    let json = getJSON(DefaultShapes.ngon)
     let decodedShape = try! JSONDecoder().decode(NgonShape.self, from: json)
     XCTAssertEqual(decodedShape.id, "shape")
     XCTAssertEqual(decodedShape.sides, 8)
@@ -262,6 +279,25 @@ class NgonShapeTests: XCTestCase {
     XCTAssertEqual(decodedShape.strokeColor, .red)
     XCTAssertEqual(decodedShape.strokeWidth, 10)
     XCTAssertEqual(decodedShape.transform, defaultTransform)
+  }
+
+}
+
+class PenShapeTests: XCTestCase {
+
+  func testSerialize() {
+    let json = getJSON(DefaultShapes.eraser)
+    let decodedShape = try! JSONDecoder().decode(PenShape.self, from: json)
+    XCTAssertEqual(decodedShape.id, "shape")
+    XCTAssertEqual(decodedShape.start, CGPoint(x: 1, y: 1))
+    XCTAssertEqual(decodedShape.segments, [
+      PenLineSegment(a: CGPoint(x: 1, y: 1), b: CGPoint(x: 2, y: 2), width: 1),
+      PenLineSegment(a: CGPoint(x: 2, y: 2), b: CGPoint(x: 3, y: 3), width: 2),
+    ])
+    XCTAssertEqual(decodedShape.isFinished, true)
+    XCTAssertEqual(decodedShape.isEraser, true)
+    XCTAssertEqual(decodedShape.strokeColor, .red)
+    XCTAssertEqual(decodedShape.strokeWidth, 10)
   }
 
 }

--- a/Drawsana Tests/DrawsanaTests.swift
+++ b/Drawsana Tests/DrawsanaTests.swift
@@ -9,8 +9,134 @@
 import XCTest
 @testable import Drawsana
 
-class AMDrawingViewTests: XCTestCase {
-    
+func getJSON<T: Encodable>(_ e: T) -> Data {
+  let encoder = JSONEncoder()
+  encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+  return try! encoder.encode(e)
+}
 
+class LineShapeTests: XCTestCase {
+
+  var defaultShape: LineShape {
+    let shape = Drawsana.LineShape()
+    shape.id = "shape"
+    shape.a = CGPoint(x: 1, y: 1)
+    shape.b = CGPoint(x: 2, y: 2)
+    shape.arrowStyle = .standard
+    shape.capStyle = .butt
+    shape.dashLengths = [1, 1]
+    shape.dashPhase = 1
+    shape.joinStyle = .bevel
+    shape.strokeColor = .red
+    shape.strokeWidth = 10
+    shape.transform = ShapeTransform(
+      translation: CGPoint(x: 3, y: 3),
+      rotation: 4,
+      scale: 5)
+    return shape
+  }
+
+  func testSerialize() {
+    let json = getJSON(defaultShape)
+    let decodedShape = try! JSONDecoder().decode(LineShape.self, from: json)
+    XCTAssertEqual(decodedShape.id, "shape")
+    XCTAssertEqual(decodedShape.a, CGPoint(x: 1, y: 1))
+    XCTAssertEqual(decodedShape.b, CGPoint(x: 2, y: 2))
+    XCTAssertEqual(decodedShape.arrowStyle, .standard)
+    XCTAssertEqual(decodedShape.capStyle, .butt)
+    XCTAssertEqual(decodedShape.dashLengths, [1, 1])
+    XCTAssertEqual(decodedShape.dashPhase, 1)
+    XCTAssertEqual(decodedShape.joinStyle, .bevel)
+    XCTAssertEqual(decodedShape.strokeColor, .red)
+    XCTAssertEqual(decodedShape.strokeWidth, 10)
+    XCTAssertEqual(
+      decodedShape.transform,
+      ShapeTransform(
+        translation: CGPoint(x: 3, y: 3),
+        rotation: 4,
+        scale: 5))
+
+  }
     
+}
+
+class RectShapeTests: XCTestCase {
+
+  var defaultShape: RectShape {
+    let shape = Drawsana.RectShape()
+    shape.id = "shape"
+    shape.a = CGPoint(x: 1, y: 1)
+    shape.b = CGPoint(x: 2, y: 2)
+    shape.capStyle = .butt
+    shape.dashLengths = [1, 1]
+    shape.dashPhase = 1
+    shape.fillColor = .yellow
+    shape.joinStyle = .bevel
+    shape.strokeColor = .red
+    shape.strokeWidth = 10
+    shape.transform = ShapeTransform(
+      translation: CGPoint(x: 3, y: 3),
+      rotation: 4,
+      scale: 5)
+    return shape
+  }
+
+  func testSerialize() {
+    let json = getJSON(defaultShape)
+    let decodedShape = try! JSONDecoder().decode(RectShape.self, from: json)
+    XCTAssertEqual(decodedShape.id, "shape")
+    XCTAssertEqual(decodedShape.a, CGPoint(x: 1, y: 1))
+    XCTAssertEqual(decodedShape.b, CGPoint(x: 2, y: 2))
+    XCTAssertEqual(decodedShape.capStyle, .butt)
+    XCTAssertEqual(decodedShape.dashLengths, [1, 1])
+    XCTAssertEqual(decodedShape.dashPhase, 1)
+    XCTAssertEqual(decodedShape.fillColor, .yellow)
+    XCTAssertEqual(decodedShape.joinStyle, .bevel)
+    XCTAssertEqual(decodedShape.strokeColor, .red)
+    XCTAssertEqual(decodedShape.strokeWidth, 10)
+    XCTAssertEqual(
+      decodedShape.transform,
+      ShapeTransform(
+        translation: CGPoint(x: 3, y: 3),
+        rotation: 4,
+        scale: 5))
+  }
+
+}
+
+
+class TextShapeTests: XCTestCase {
+
+  var defaultShape: TextShape {
+    let shape = Drawsana.TextShape()
+    shape.id = "shape"
+    shape.explicitWidth = 100
+    shape.fontName = "Helvetica Neue"
+    shape.fontSize = 12
+    shape.text = "xyzzy"
+    shape.fillColor = .yellow
+    shape.transform = ShapeTransform(
+      translation: CGPoint(x: 3, y: 3),
+      rotation: 4,
+      scale: 5)
+    return shape
+  }
+
+  func testSerialize() {
+    let json = getJSON(defaultShape)
+    let decodedShape = try! JSONDecoder().decode(TextShape.self, from: json)
+    XCTAssertEqual(decodedShape.id, "shape")
+    XCTAssertEqual(decodedShape.explicitWidth, 100)
+    XCTAssertEqual(decodedShape.fontName, "Helvetica Neue")
+    XCTAssertEqual(decodedShape.fontSize, 12)
+    XCTAssertEqual(decodedShape.text, "xyzzy")
+    XCTAssertEqual(decodedShape.fillColor, .yellow)
+    XCTAssertEqual(
+      decodedShape.transform,
+      ShapeTransform(
+        translation: CGPoint(x: 3, y: 3),
+        rotation: 4,
+        scale: 5))
+  }
+
 }

--- a/Drawsana Tests/DrawsanaTests.swift
+++ b/Drawsana Tests/DrawsanaTests.swift
@@ -362,3 +362,93 @@ class PenShapeTests: XCTestCase {
   }
 
 }
+
+class DrawingTests: XCTestCase {
+
+  func testBasicDecoding() {
+    Drawing.debugSerialization = true
+
+    let json = """
+      {
+        "shapes" : [
+          {
+            "a" : [
+              84,
+              70.5
+            ],
+            "b" : [
+              196.5,
+              166
+            ],
+            "id" : "F39E55DA-BF06-4EA1-B324-4C82F71CD3AA",
+            "strokeColor" : "#000000",
+            "strokeWidth" : 5,
+            "type" : "Line"
+          }
+        ],
+        "size" : [
+          320,
+          240
+        ]
+      }
+      """
+
+    let drawing = try! JSONDecoder().decode(Drawing.self, from: json.data(using: .utf8)!)
+    XCTAssertEqual(drawing.shapes.count, 1)
+  }
+
+  func testBasicDecodingErrorWithoutDebug() {
+    Drawing.debugSerialization = false
+
+    let json = """
+      {
+        "shapes" : [
+          {
+            "a" : [
+              84,
+              70.5
+            ],
+            "id" : "F39E55DA-BF06-4EA1-B324-4C82F71CD3AA",
+            "strokeColor" : "#000000",
+            "strokeWidth" : 5,
+            "type" : "Line"
+          }
+        ],
+        "size" : [
+          320,
+          240
+        ]
+      }
+      """
+
+    let drawing = try! JSONDecoder().decode(Drawing.self, from: json.data(using: .utf8)!)
+    XCTAssertEqual(drawing.shapes.count, 0)
+  }
+
+  func testBasicDecodingErrorWithDebug() {
+    Drawing.debugSerialization = true
+
+    let json = """
+      {
+        "shapes" : [
+          {
+            "a" : [
+              84,
+              70.5
+            ],
+            "id" : "F39E55DA-BF06-4EA1-B324-4C82F71CD3AA",
+            "strokeColor" : "#000000",
+            "strokeWidth" : 5,
+            "type" : "Line"
+          }
+        ],
+        "size" : [
+          320,
+          240
+        ]
+      }
+      """
+
+    XCTAssertThrowsError(try JSONDecoder().decode(Drawing.self, from: json.data(using: .utf8)!))
+  }
+}

--- a/Drawsana Tests/DrawsanaTests.swift
+++ b/Drawsana Tests/DrawsanaTests.swift
@@ -7,30 +7,10 @@
 //
 
 import XCTest
-@testable import AMDrawingView
+@testable import Drawsana
 
 class AMDrawingViewTests: XCTestCase {
     
-    override func setUp() {
-        super.setUp()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-    
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-        super.tearDown()
-    }
-    
-    func testExample() {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-    }
-    
-    func testPerformanceExample() {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
-        }
-    }
+
     
 }

--- a/Drawsana Tests/DrawsanaTests.swift
+++ b/Drawsana Tests/DrawsanaTests.swift
@@ -63,6 +63,7 @@ struct DefaultShapes {
     shape.text = "xyzzy"
     shape.fillColor = .yellow
     shape.transform = defaultTransform
+    shape.boundingRect = CGRect(x: 1, y: 2, width: 3, height: 4)
     return shape
   }
 
@@ -200,7 +201,7 @@ class TextShapeTests: XCTestCase {
     return shape
   }
 
-  func testSerializeWithExplicitWidth() {
+  func testSerializeWithExplicitWidthAndBoundingRect() {
     let json = getJSON(DefaultShapes.text)
     let decodedShape = try! JSONDecoder().decode(TextShape.self, from: json)
     XCTAssertEqual(decodedShape.id, "shape")
@@ -210,9 +211,10 @@ class TextShapeTests: XCTestCase {
     XCTAssertEqual(decodedShape.text, "xyzzy")
     XCTAssertEqual(decodedShape.fillColor, .yellow)
     XCTAssertEqual(decodedShape.transform, defaultTransform)
+    XCTAssertEqual(decodedShape.boundingRect, CGRect(x: 1, y: 2, width: 3, height: 4))
   }
 
-  func testSerializeWithoutExplicitWidth() {
+  func testSerializeWithoutExplicitWidthOrBoundingRect() {
     let json = getJSON(textShapeWithNoExplicitWidth)
     let decodedShape = try! JSONDecoder().decode(TextShape.self, from: json)
     XCTAssertEqual(decodedShape.id, "shape")
@@ -222,6 +224,7 @@ class TextShapeTests: XCTestCase {
     XCTAssertEqual(decodedShape.text, "xyzzy")
     XCTAssertEqual(decodedShape.fillColor, .yellow)
     XCTAssertEqual(decodedShape.transform, defaultTransform)
+    XCTAssertEqual(decodedShape.boundingRect, .zero)
   }
 
   func testDeserializationFromJSON() {

--- a/Drawsana Tests/DrawsanaTests.swift
+++ b/Drawsana Tests/DrawsanaTests.swift
@@ -15,10 +15,15 @@ func getJSON<T: Encodable>(_ e: T) -> Data {
   return try! encoder.encode(e)
 }
 
+let defaultTransform = ShapeTransform(
+  translation: CGPoint(x: 3, y: 3),
+  rotation: 4,
+  scale: 5)
+
 class LineShapeTests: XCTestCase {
 
   var defaultShape: LineShape {
-    let shape = Drawsana.LineShape()
+    let shape = LineShape()
     shape.id = "shape"
     shape.a = CGPoint(x: 1, y: 1)
     shape.b = CGPoint(x: 2, y: 2)
@@ -29,10 +34,7 @@ class LineShapeTests: XCTestCase {
     shape.joinStyle = .bevel
     shape.strokeColor = .red
     shape.strokeWidth = 10
-    shape.transform = ShapeTransform(
-      translation: CGPoint(x: 3, y: 3),
-      rotation: 4,
-      scale: 5)
+    shape.transform = defaultTransform
     return shape
   }
 
@@ -49,12 +51,7 @@ class LineShapeTests: XCTestCase {
     XCTAssertEqual(decodedShape.joinStyle, .bevel)
     XCTAssertEqual(decodedShape.strokeColor, .red)
     XCTAssertEqual(decodedShape.strokeWidth, 10)
-    XCTAssertEqual(
-      decodedShape.transform,
-      ShapeTransform(
-        translation: CGPoint(x: 3, y: 3),
-        rotation: 4,
-        scale: 5))
+    XCTAssertEqual(decodedShape.transform, defaultTransform)
 
   }
     
@@ -63,7 +60,7 @@ class LineShapeTests: XCTestCase {
 class RectShapeTests: XCTestCase {
 
   var defaultShape: RectShape {
-    let shape = Drawsana.RectShape()
+    let shape = RectShape()
     shape.id = "shape"
     shape.a = CGPoint(x: 1, y: 1)
     shape.b = CGPoint(x: 2, y: 2)
@@ -74,10 +71,7 @@ class RectShapeTests: XCTestCase {
     shape.joinStyle = .bevel
     shape.strokeColor = .red
     shape.strokeWidth = 10
-    shape.transform = ShapeTransform(
-      translation: CGPoint(x: 3, y: 3),
-      rotation: 4,
-      scale: 5)
+    shape.transform = defaultTransform
     return shape
   }
 
@@ -94,31 +88,22 @@ class RectShapeTests: XCTestCase {
     XCTAssertEqual(decodedShape.joinStyle, .bevel)
     XCTAssertEqual(decodedShape.strokeColor, .red)
     XCTAssertEqual(decodedShape.strokeWidth, 10)
-    XCTAssertEqual(
-      decodedShape.transform,
-      ShapeTransform(
-        translation: CGPoint(x: 3, y: 3),
-        rotation: 4,
-        scale: 5))
+    XCTAssertEqual(decodedShape.transform, defaultTransform)
   }
 
 }
 
-
 class TextShapeTests: XCTestCase {
 
   var defaultShape: TextShape {
-    let shape = Drawsana.TextShape()
+    let shape = TextShape()
     shape.id = "shape"
     shape.explicitWidth = 100
     shape.fontName = "Helvetica Neue"
     shape.fontSize = 12
     shape.text = "xyzzy"
     shape.fillColor = .yellow
-    shape.transform = ShapeTransform(
-      translation: CGPoint(x: 3, y: 3),
-      rotation: 4,
-      scale: 5)
+    shape.transform = defaultTransform
     return shape
   }
 
@@ -131,12 +116,152 @@ class TextShapeTests: XCTestCase {
     XCTAssertEqual(decodedShape.fontSize, 12)
     XCTAssertEqual(decodedShape.text, "xyzzy")
     XCTAssertEqual(decodedShape.fillColor, .yellow)
-    XCTAssertEqual(
-      decodedShape.transform,
-      ShapeTransform(
-        translation: CGPoint(x: 3, y: 3),
-        rotation: 4,
-        scale: 5))
+    XCTAssertEqual(decodedShape.transform, defaultTransform)
+  }
+
+}
+
+class EllipseShapeTests: XCTestCase {
+
+  var defaultShape: EllipseShape {
+    let shape = EllipseShape()
+    shape.id = "shape"
+    shape.a = CGPoint(x: 1, y: 1)
+    shape.b = CGPoint(x: 2, y: 2)
+    shape.capStyle = .butt
+    shape.dashLengths = [1, 1]
+    shape.dashPhase = 1
+    shape.fillColor = .yellow
+    shape.joinStyle = .bevel
+    shape.strokeColor = .red
+    shape.strokeWidth = 10
+    shape.transform = defaultTransform
+    return shape
+  }
+
+  func testSerialize() {
+    let json = getJSON(defaultShape)
+    let decodedShape = try! JSONDecoder().decode(EllipseShape.self, from: json)
+    XCTAssertEqual(decodedShape.id, "shape")
+    XCTAssertEqual(decodedShape.a, CGPoint(x: 1, y: 1))
+    XCTAssertEqual(decodedShape.b, CGPoint(x: 2, y: 2))
+    XCTAssertEqual(decodedShape.capStyle, .butt)
+    XCTAssertEqual(decodedShape.dashLengths, [1, 1])
+    XCTAssertEqual(decodedShape.dashPhase, 1)
+    XCTAssertEqual(decodedShape.fillColor, .yellow)
+    XCTAssertEqual(decodedShape.joinStyle, .bevel)
+    XCTAssertEqual(decodedShape.strokeColor, .red)
+    XCTAssertEqual(decodedShape.strokeWidth, 10)
+    XCTAssertEqual(decodedShape.transform, defaultTransform)
+  }
+
+}
+
+class AngleShapeTests: XCTestCase {
+
+  var defaultShape: AngleShape {
+    let shape = AngleShape()
+    shape.id = "shape"
+    shape.a = CGPoint(x: 1, y: 1)
+    shape.b = CGPoint(x: 2, y: 2)
+    shape.c = CGPoint(x: 20, y: 20)
+    shape.capStyle = .butt
+    shape.dashLengths = [1, 1]
+    shape.dashPhase = 1
+    shape.joinStyle = .bevel
+    shape.strokeColor = .red
+    shape.strokeWidth = 10
+    shape.transform = defaultTransform
+    return shape
+  }
+
+  func testSerialize() {
+    let json = getJSON(defaultShape)
+    let decodedShape = try! JSONDecoder().decode(AngleShape.self, from: json)
+    XCTAssertEqual(decodedShape.id, "shape")
+    XCTAssertEqual(decodedShape.a, CGPoint(x: 1, y: 1))
+    XCTAssertEqual(decodedShape.b, CGPoint(x: 2, y: 2))
+    XCTAssertEqual(decodedShape.c, CGPoint(x: 20, y: 20))
+    XCTAssertEqual(decodedShape.capStyle, .butt)
+    XCTAssertEqual(decodedShape.dashLengths, [1, 1])
+    XCTAssertEqual(decodedShape.dashPhase, 1)
+    XCTAssertEqual(decodedShape.joinStyle, .bevel)
+    XCTAssertEqual(decodedShape.strokeColor, .red)
+    XCTAssertEqual(decodedShape.strokeWidth, 10)
+    XCTAssertEqual(decodedShape.transform, defaultTransform)
+  }
+
+}
+
+class StarShapeTests: XCTestCase {
+
+  var defaultShape: StarShape {
+    let shape = StarShape()
+    shape.id = "shape"
+    shape.a = CGPoint(x: 1, y: 1)
+    shape.b = CGPoint(x: 2, y: 2)
+    shape.capStyle = .butt
+    shape.dashLengths = [1, 1]
+    shape.dashPhase = 1
+    shape.fillColor = .yellow
+    shape.joinStyle = .bevel
+    shape.strokeColor = .red
+    shape.strokeWidth = 10
+    shape.transform = defaultTransform
+    return shape
+  }
+
+  func testSerialize() {
+    let json = getJSON(defaultShape)
+    let decodedShape = try! JSONDecoder().decode(StarShape.self, from: json)
+    XCTAssertEqual(decodedShape.id, "shape")
+    XCTAssertEqual(decodedShape.a, CGPoint(x: 1, y: 1))
+    XCTAssertEqual(decodedShape.b, CGPoint(x: 2, y: 2))
+    XCTAssertEqual(decodedShape.capStyle, .butt)
+    XCTAssertEqual(decodedShape.dashLengths, [1, 1])
+    XCTAssertEqual(decodedShape.dashPhase, 1)
+    XCTAssertEqual(decodedShape.fillColor, .yellow)
+    XCTAssertEqual(decodedShape.joinStyle, .bevel)
+    XCTAssertEqual(decodedShape.strokeColor, .red)
+    XCTAssertEqual(decodedShape.strokeWidth, 10)
+    XCTAssertEqual(decodedShape.transform, defaultTransform)
+  }
+
+}
+
+class NgonShapeTests: XCTestCase {
+
+  var defaultShape: NgonShape {
+    let shape = NgonShape(8)
+    shape.id = "shape"
+    shape.a = CGPoint(x: 1, y: 1)
+    shape.b = CGPoint(x: 2, y: 2)
+    shape.capStyle = .butt
+    shape.dashLengths = [1, 1]
+    shape.dashPhase = 1
+    shape.fillColor = .yellow
+    shape.joinStyle = .bevel
+    shape.strokeColor = .red
+    shape.strokeWidth = 10
+    shape.transform = defaultTransform
+    return shape
+  }
+
+  func testSerialize() {
+    let json = getJSON(defaultShape)
+    let decodedShape = try! JSONDecoder().decode(NgonShape.self, from: json)
+    XCTAssertEqual(decodedShape.id, "shape")
+    XCTAssertEqual(decodedShape.sides, 8)
+    XCTAssertEqual(decodedShape.a, CGPoint(x: 1, y: 1))
+    XCTAssertEqual(decodedShape.b, CGPoint(x: 2, y: 2))
+    XCTAssertEqual(decodedShape.capStyle, .butt)
+    XCTAssertEqual(decodedShape.dashLengths, [1, 1])
+    XCTAssertEqual(decodedShape.dashPhase, 1)
+    XCTAssertEqual(decodedShape.fillColor, .yellow)
+    XCTAssertEqual(decodedShape.joinStyle, .bevel)
+    XCTAssertEqual(decodedShape.strokeColor, .red)
+    XCTAssertEqual(decodedShape.strokeWidth, 10)
+    XCTAssertEqual(decodedShape.transform, defaultTransform)
   }
 
 }

--- a/Drawsana Tests/DrawsanaTests.swift
+++ b/Drawsana Tests/DrawsanaTests.swift
@@ -188,7 +188,19 @@ class RectShapeTests: XCTestCase {
 
 class TextShapeTests: XCTestCase {
 
-  func testSerialize() {
+  var textShapeWithNoExplicitWidth: TextShape {
+    let shape = TextShape()
+    shape.id = "shape"
+    shape.explicitWidth = nil
+    shape.fontName = "Helvetica Neue"
+    shape.fontSize = 12
+    shape.text = "xyzzy"
+    shape.fillColor = .yellow
+    shape.transform = defaultTransform
+    return shape
+  }
+
+  func testSerializeWithExplicitWidth() {
     let json = getJSON(DefaultShapes.text)
     let decodedShape = try! JSONDecoder().decode(TextShape.self, from: json)
     XCTAssertEqual(decodedShape.id, "shape")
@@ -198,6 +210,52 @@ class TextShapeTests: XCTestCase {
     XCTAssertEqual(decodedShape.text, "xyzzy")
     XCTAssertEqual(decodedShape.fillColor, .yellow)
     XCTAssertEqual(decodedShape.transform, defaultTransform)
+  }
+
+  func testSerializeWithoutExplicitWidth() {
+    let json = getJSON(textShapeWithNoExplicitWidth)
+    let decodedShape = try! JSONDecoder().decode(TextShape.self, from: json)
+    XCTAssertEqual(decodedShape.id, "shape")
+    XCTAssertEqual(decodedShape.explicitWidth, nil)
+    XCTAssertEqual(decodedShape.fontName, "Helvetica Neue")
+    XCTAssertEqual(decodedShape.fontSize, 12)
+    XCTAssertEqual(decodedShape.text, "xyzzy")
+    XCTAssertEqual(decodedShape.fillColor, .yellow)
+    XCTAssertEqual(decodedShape.transform, defaultTransform)
+  }
+
+  func testDeserializationFromJSON() {
+    let jsonString = """
+      {
+        "fillColor" : "#000000",
+        "fontName" : "Marker Felt",
+        "fontSize" : 24,
+        "id" : "193B98AC-56A9-4038-9345-30D5BFDCFD84",
+        "text" : "Text",
+        "transform" : {
+          "rotation" : 0,
+          "scale" : 1,
+          "translation" : [
+            103.5,
+            110.5
+          ]
+        },
+        "type" : "Text"
+      }
+      """
+
+    let decodedShape = try! JSONDecoder().decode(
+      TextShape.self,
+      from: jsonString.data(using: .utf8)!)
+    XCTAssertEqual(decodedShape.id, "193B98AC-56A9-4038-9345-30D5BFDCFD84")
+    XCTAssertEqual(decodedShape.explicitWidth, nil)
+    XCTAssertEqual(decodedShape.fontName, "Marker Felt")
+    XCTAssertEqual(decodedShape.fontSize, 24)
+    XCTAssertEqual(decodedShape.text, "Text")
+    XCTAssertEqual(decodedShape.fillColor, UIColor(hexString: "#000000"))
+    XCTAssertEqual(
+      decodedShape.transform,
+      ShapeTransform(translation: CGPoint(x: 103.5, y: 110.5), rotation: 0, scale: 1))
   }
 
 }

--- a/Drawsana.xcodeproj/project.pbxproj
+++ b/Drawsana.xcodeproj/project.pbxproj
@@ -756,13 +756,13 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = A679L395M8;
-				INFOPLIST_FILE = AMDrawingViewTests/Info.plist;
+				INFOPLIST_FILE = "Drawsana Tests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.asana.AMDrawingViewTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.asana.DrawsanaTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -775,13 +775,13 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = A679L395M8;
-				INFOPLIST_FILE = AMDrawingViewTests/Info.plist;
+				INFOPLIST_FILE = "Drawsana Tests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.asana.AMDrawingViewTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.asana.DrawsanaTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/Drawsana/Data model/Drawing.swift
+++ b/Drawsana/Data model/Drawing.swift
@@ -170,10 +170,6 @@ public enum DrawsanaDecodingError: Error {
 
 // MARK: Codable helpers
 
-/// If debug is off and we hit a shape with errors, use this struct to skip
-/// the current item
-private struct DummyCodable: Codable { }
-
 /// Wrap any non-concrete `Encodable` type (like a `Shape`) in this class to
 /// magically make it work with `container.encode(foo, forKey: .foo)`.
 private struct AnyEncodable: Encodable {

--- a/Drawsana/Data model/Drawing.swift
+++ b/Drawsana/Data model/Drawing.swift
@@ -91,14 +91,15 @@ public class Drawing: Codable {
       // to crash here for now, but a custom error enum might be a good idea
       // in the future.
       if shapes.count == countBefore {
+        // Use a special CodingKeys enum that only cares about the `type`, so
+        // we can report exactly what kind of thing can't be parsed
+        let typeContainer = try shapeIter.nestedContainer(keyedBy: ShapeTypeCodingKey.self)
+        let type = try typeContainer.decode(String.self, forKey: .type)
+
+        // If in debug mode, this is an error. Otherwise, just ignore it and
+        // move on.
         if Drawing.debugSerialization {
-          // Use a special CodingKeys enum that only cares about the `type`, so
-          // we can report exactly what kind of thing can't be parsed
-          let typeContainer = try shapeIter.nestedContainer(keyedBy: ShapeTypeCodingKey.self)
-          let type = try typeContainer.decode(String.self, forKey: .type)
           throw DrawsanaDecodingError.unknownShapeTypeError(type)
-        } else {
-          _ = try! shapeIter.decode(DummyCodable.self)
         }
       }
     }

--- a/Drawsana/Data model/Drawing.swift
+++ b/Drawsana/Data model/Drawing.swift
@@ -90,12 +90,16 @@ public class Drawing: Codable {
       // Decoding failed, so bail out with a helpful error message. We choose
       // to crash here for now, but a custom error enum might be a good idea
       // in the future.
-      if shapes.count == countBefore && Drawing.debugSerialization {
-        // Use a special CodingKeys enum that only cares about the `type`, so
-        // we can report exactly what kind of thing can't be parsed
-        let typeContainer = try shapeIter.nestedContainer(keyedBy: ShapeTypeCodingKey.self)
-        let type = try typeContainer.decode(String.self, forKey: .type)
-        throw DrawsanaDecodingError.unknownShapeTypeError(type)
+      if shapes.count == countBefore {
+        if Drawing.debugSerialization {
+          // Use a special CodingKeys enum that only cares about the `type`, so
+          // we can report exactly what kind of thing can't be parsed
+          let typeContainer = try shapeIter.nestedContainer(keyedBy: ShapeTypeCodingKey.self)
+          let type = try typeContainer.decode(String.self, forKey: .type)
+          throw DrawsanaDecodingError.unknownShapeTypeError(type)
+        } else {
+          _ = try! shapeIter.decode(DummyCodable.self)
+        }
       }
     }
   }
@@ -164,6 +168,10 @@ public enum DrawsanaDecodingError: Error {
 }
 
 // MARK: Codable helpers
+
+/// If debug is off and we hit a shape with errors, use this struct to skip
+/// the current item
+private struct DummyCodable: Codable { }
 
 /// Wrap any non-concrete `Encodable` type (like a `Shape`) in this class to
 /// magically make it work with `container.encode(foo, forKey: .foo)`.

--- a/Drawsana/DrawsanaView.swift
+++ b/Drawsana/DrawsanaView.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public let DRAWSANA_VERSION = "0.9.5"
+public let DRAWSANA_VERSION = "0.10.0"
 
 /// Set yourself as the `DrawsanaView`'s delegate to be notified when the active
 /// tool changes.

--- a/Drawsana/DrawsanaView.swift
+++ b/Drawsana/DrawsanaView.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public let DRAWSANA_VERSION = "1.0"
+public let DRAWSANA_VERSION = "0.9.5"
 
 /// Set yourself as the `DrawsanaView`'s delegate to be notified when the active
 /// tool changes.

--- a/Drawsana/DrawsanaView.swift
+++ b/Drawsana/DrawsanaView.swift
@@ -51,7 +51,8 @@ public class DrawsanaView: UIView {
 
   public var drawing: Drawing = Drawing(size: CGSize(width: 320, height: 320)) {
     didSet {
-      self.tool?.deactivate(context: self.toolOperationContext)
+      tool?.deactivate(context: self.toolOperationContext)
+      operationStack = DrawingOperationStack(drawing: drawing)
       drawing.delegate = self
       drawing.size = bounds.size
       tool?.activate(shapeUpdater: self, context: self.toolOperationContext, shape: nil)

--- a/Drawsana/DrawsanaView.swift
+++ b/Drawsana/DrawsanaView.swift
@@ -51,8 +51,14 @@ public class DrawsanaView: UIView {
 
   public var drawing: Drawing = Drawing(size: CGSize(width: 320, height: 320)) {
     didSet {
+      self.tool?.deactivate(context: self.toolOperationContext)
       drawing.delegate = self
       drawing.size = bounds.size
+      tool?.activate(shapeUpdater: self, context: self.toolOperationContext, shape: nil)
+      applyToolSettingsChanges()
+      if let tool = tool {
+        delegate?.drawsanaView(self, didSwitchTo: tool)
+      }
       redrawAbsolutelyEverything()
     }
   }

--- a/Drawsana/Shapes/Implementations/NgonShape.swift
+++ b/Drawsana/Shapes/Implementations/NgonShape.swift
@@ -53,6 +53,7 @@ public class NgonShape:
         id = try values.decode(String.self, forKey: .id)
         a = try values.decode(CGPoint.self, forKey: .a)
         b = try values.decode(CGPoint.self, forKey: .b)
+        sides = try values.decode(Int.self, forKey: .sides)
         
         strokeColor = try values.decodeColorIfPresent(forKey: .strokeColor)
         fillColor = try values.decodeColorIfPresent(forKey: .fillColor)
@@ -72,6 +73,7 @@ public class NgonShape:
         try container.encode(id, forKey: .id)
         try container.encode(a, forKey: .a)
         try container.encode(b, forKey: .b)
+        try container.encode(sides, forKey: .sides)
         try container.encode(strokeColor?.hexString, forKey: .strokeColor)
         try container.encode(fillColor?.hexString, forKey: .fillColor)
         try container.encode(strokeWidth, forKey: .strokeWidth)

--- a/Drawsana/Shapes/Implementations/PenShape.swift
+++ b/Drawsana/Shapes/Implementations/PenShape.swift
@@ -17,10 +17,6 @@ public struct PenLineSegment: Codable, Equatable {
   public var midPoint: CGPoint {
     return CGPoint(x: (a.x + b.x) / 2, y: (a.y + b.y) / 2)
   }
-
-  public static func ==(_ a: PenLineSegment, _ b: PenLineSegment) -> Bool {
-    return a.a == b.a && a.b == b.b && a.width == b.width
-  }
 }
 
 public class PenShape: Shape, ShapeWithStrokeState {

--- a/Drawsana/Shapes/Implementations/PenShape.swift
+++ b/Drawsana/Shapes/Implementations/PenShape.swift
@@ -9,13 +9,17 @@
 import CoreGraphics
 import UIKit
 
-public struct PenLineSegment: Codable {
-  var a: CGPoint
-  var b: CGPoint
-  var width: CGFloat
+public struct PenLineSegment: Codable, Equatable {
+  public var a: CGPoint
+  public var b: CGPoint
+  public var width: CGFloat
 
-  var midPoint: CGPoint {
+  public var midPoint: CGPoint {
     return CGPoint(x: (a.x + b.x) / 2, y: (a.y + b.y) / 2)
+  }
+
+  public static func ==(_ a: PenLineSegment, _ b: PenLineSegment) -> Bool {
+    return a.a == b.a && a.b == b.b && a.width == b.width
   }
 }
 

--- a/Drawsana/Shapes/Implementations/TextShape.swift
+++ b/Drawsana/Shapes/Implementations/TextShape.swift
@@ -60,7 +60,7 @@ public class TextShape: Shape, ShapeSelectable {
     transform = try values.decode(ShapeTransform.self, forKey: .transform)
 
     if boundingRect == .zero {
-      print("Text bounding rect not present. This shape will not render correctly because of a bug in Drawsana <=0.9.*.")
+      print("Text bounding rect not present. This shape will not render correctly because of a bug in Drawsana <0.9.5.")
     }
   }
 

--- a/Drawsana/Shapes/Implementations/TextShape.swift
+++ b/Drawsana/Shapes/Implementations/TextShape.swift
@@ -11,7 +11,8 @@ import UIKit
 
 public class TextShape: Shape, ShapeSelectable {
   private enum CodingKeys: String, CodingKey {
-    case id, transform, text, fontName, fontSize, fillColor, type, explicitWidth
+    case id, transform, text, fontName, fontSize, fillColor, type,
+      explicitWidth, boundingRect
   }
 
   public static let type = "Text"
@@ -55,7 +56,12 @@ public class TextShape: Shape, ShapeSelectable {
     fontSize = try values.decode(CGFloat.self, forKey: .fontSize)
     fillColor = UIColor(hexString: try values.decode(String.self, forKey: .fillColor))
     explicitWidth = try values.decodeIfPresent(CGFloat.self, forKey: .explicitWidth)
+    boundingRect = try values.decodeIfPresent(CGRect.self, forKey: .boundingRect) ?? .zero
     transform = try values.decode(ShapeTransform.self, forKey: .transform)
+
+    if boundingRect == .zero {
+      print("Text bounding rect not present. This shape will not render correctly because of a bug in Drawsana <=0.9.*.")
+    }
   }
 
   public func encode(to encoder: Encoder) throws {
@@ -68,6 +74,7 @@ public class TextShape: Shape, ShapeSelectable {
     try container.encode(fontSize, forKey: .fontSize)
     try container.encodeIfPresent(explicitWidth, forKey: .explicitWidth)
     try container.encode(transform, forKey: .transform)
+    try container.encode(boundingRect, forKey: .boundingRect)
   }
 
   public func render(in context: CGContext) {

--- a/Drawsana/Shapes/Implementations/TextShape.swift
+++ b/Drawsana/Shapes/Implementations/TextShape.swift
@@ -60,7 +60,7 @@ public class TextShape: Shape, ShapeSelectable {
     transform = try values.decode(ShapeTransform.self, forKey: .transform)
 
     if boundingRect == .zero {
-      print("Text bounding rect not present. This shape will not render correctly because of a bug in Drawsana <0.9.5.")
+      print("Text bounding rect not present. This shape will not render correctly because of a bug in Drawsana <0.10.0.")
     }
   }
 

--- a/Drawsana/Shapes/ShapeTransform.swift
+++ b/Drawsana/Shapes/ShapeTransform.swift
@@ -18,12 +18,6 @@ public struct ShapeTransform: Codable, Equatable {
   public var scale: CGFloat
 
   public static let identity = ShapeTransform(translation: .zero, rotation: 0, scale: 1)
-
-  public static func ==(_ a: ShapeTransform, _ b: ShapeTransform) -> Bool {
-    return a.translation == b.translation &&
-      a.rotation == b.rotation &&
-      a.scale == b.scale
-  }
 }
 
 extension ShapeTransform {

--- a/Drawsana/Shapes/ShapeTransform.swift
+++ b/Drawsana/Shapes/ShapeTransform.swift
@@ -12,12 +12,18 @@ import CoreGraphics
  Simplified representation of three ordered affine transforms (translate,
  rotate, scale) that can be applied to `ShapeWithTransform`.
  */
-public struct ShapeTransform: Codable {
+public struct ShapeTransform: Codable, Equatable {
   public var translation: CGPoint
   public var rotation: CGFloat
   public var scale: CGFloat
 
   public static let identity = ShapeTransform(translation: .zero, rotation: 0, scale: 1)
+
+  public static func ==(_ a: ShapeTransform, _ b: ShapeTransform) -> Bool {
+    return a.translation == b.translation &&
+      a.rotation == b.rotation &&
+      a.scale == b.scale
+  }
 }
 
 extension ShapeTransform {

--- a/Readme.md
+++ b/Readme.md
@@ -95,6 +95,12 @@ open https://asana.github.io/Drawsana
 
 ## Changelog
 
+### 0.10 (in progress)
+* Fix `NgonShape` serialization bug
+* Deserialization error reporting is more detailed. Shapes that find a JSON object with
+  the correct type will now throw errors instead of causing the whole operation to silently
+  fail.
+
 ### 0.9.4
 * Star, triangle, pentagon, and angle tools
 * `DrawsanaView.render()` accepts a `scale` parameter instead of always using zero

--- a/Readme.md
+++ b/Readme.md
@@ -97,10 +97,15 @@ open https://asana.github.io/Drawsana
 
 ### 0.9.5 (in progress)
 * Convert to Swift 5
-* Fix `NgonShape` serialization bug
+* Fix `NgonShape` and `TextShape` serialization bugs. Old data can't be fixed, but
+  new data will be correct.
 * Deserialization error reporting is more detailed. Shapes that find a JSON object with
   the correct type will now throw errors instead of causing the whole operation to silently
-  fail.
+  fail, as long as you enable `Drawing.debugSerialization`.
+* Replacing `DrawingView.drawing` now behaves correctly instead of being unusably
+  buggy.
+* `PenLineSegment`'s members are now public.
+* `ShapeTransform` and `PenLineSegment` are now `Equatable`.
 
 ### 0.9.4
 * Star, triangle, pentagon, and angle tools

--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-#  Drawsana 0.9.2
+#  Drawsana 0.9.5
 
 Drawsana is a generalized framework for making freehand drawing views on iOS. You can
 let users scribble over images, add shapes and text, and even make your own tools.
@@ -32,7 +32,7 @@ Add `Asana/Drawsana` to your Cartfile and update your project like you would for
 Carthage framework, or clone the source code and add the project to your workspace.
 
 ```
-github "Asana/Drawsana" == 0.9.2
+github "Asana/Drawsana" == 0.9.4
 ```
 
 ## Usage

--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-#  Drawsana 0.9.5
+#  Drawsana 0.10.0
 
 Drawsana is a generalized framework for making freehand drawing views on iOS. You can
 let users scribble over images, add shapes and text, and even make your own tools.
@@ -95,7 +95,7 @@ open https://asana.github.io/Drawsana
 
 ## Changelog
 
-### 0.9.5 (in progress)
+### 0.10.0
 * Convert to Swift 5
 * Fix `NgonShape` and `TextShape` serialization bugs. Old data can't be fixed, but
   new data will be correct.

--- a/Readme.md
+++ b/Readme.md
@@ -95,7 +95,8 @@ open https://asana.github.io/Drawsana
 
 ## Changelog
 
-### 0.10 (in progress)
+### 0.9.5 (in progress)
+* Convert to Swift 5
 * Fix `NgonShape` serialization bug
 * Deserialization error reporting is more detailed. Shapes that find a JSON object with
   the correct type will now throw errors instead of causing the whole operation to silently


### PR DESCRIPTION
Fixes #13, #21, #27, and more unreported bugs.

# Docs

Fixes Jazzy docs to have correct categories on classes added by contributors.

# Unit tests

- The unit test target compiles
- Each shape has a serialization test
- `Drawing` also has serialization tests for different failure modes

# Bugs

## Shapes

- Ngons encode and decode properly
- Text now saves its bounding rect, because there's no way to derive it without the tool instance

## Drawing serialization

- Replacing `DrawingView.drawing` is much more correct
  - `DrawingView.drawingOperationStack` is replaced with a fresh instance that references the new drawing instance instead of hanging on to the old one
  - The tool is deactivated and reactivated to pick up new information
- Add static `Drawing.debugSerialization` flag. When the flag is disabled, shapes with decoding errors are skipped. When enabled, the errors are raised.

## Other

- `PenLineSegment`'s members are now public
- `PenLineSegment` and `ShapeTransform` are equatable
