### PR TITLE
set access of DrawingToolForShapeWith(Two/Three)Points to open

### DIFF
--- a/Drawsana/Tools/Implementations/DrawingToolForShapeWithThreePoints.swift
+++ b/Drawsana/Tools/Implementations/DrawingToolForShapeWithThreePoints.swift
@@ -13,10 +13,10 @@ import CoreGraphics
 /**
  Base class for tools (angle)
  */
-public class DrawingToolForShapeWithThreePoints: DrawingTool {
+open class DrawingToolForShapeWithThreePoints: DrawingTool {
   public typealias ShapeType = Shape & ShapeWithThreePoints
   
-  public var name: String { fatalError("Override me") }
+  open var name: String { fatalError("Override me") }
   
   public var shapeInProgress: ShapeType?
   
@@ -27,7 +27,7 @@ public class DrawingToolForShapeWithThreePoints: DrawingTool {
   public init() { }
   
   /// Override this method to return a shape ready to be drawn to the screen.
-  public func makeShape() -> ShapeType {
+  open func makeShape() -> ShapeType {
     fatalError("Override me")
   }
   

--- a/Drawsana/Tools/Implementations/DrawingToolForShapeWithTwoPoints.swift
+++ b/Drawsana/Tools/Implementations/DrawingToolForShapeWithTwoPoints.swift
@@ -12,10 +12,10 @@ import CoreGraphics
  Base class for tools (rect, line, ellipse) that are drawn by dragging from
  one point to another
  */
-public class DrawingToolForShapeWithTwoPoints: DrawingTool {
+open class DrawingToolForShapeWithTwoPoints: DrawingTool {
   public typealias ShapeType = Shape & ShapeWithTwoPoints
 
-  public var name: String { fatalError("Override me") }
+  open var name: String { fatalError("Override me") }
 
   public var shapeInProgress: ShapeType?
 
@@ -24,7 +24,7 @@ public class DrawingToolForShapeWithTwoPoints: DrawingTool {
   public init() { }
 
   /// Override this method to return a shape ready to be drawn to the screen.
-  public func makeShape() -> ShapeType {
+  open func makeShape() -> ShapeType {
     fatalError("Override me")
   }
 


### PR DESCRIPTION
By making the DrawingToolForShapeWithTwoPoints and DrawingToolForShapeWithThreePoints class 'open' instead of 'public' it would be possible to subclass them and therefore be easier for developers to create own shapes, which depend on two or three points, and the corresponding tools.