### PR TITLE
Fix: Text editing with >1 shape doesn't work 

### DIFF
--- a/Drawsana/Tools/Implementations/Text tool/TextTool.swift
+++ b/Drawsana/Tools/Implementations/Text tool/TextTool.swift
@@ -237,7 +237,7 @@ public class TextTool: NSObject, DrawingTool {
 
   func updateTextView() {
     guard let shape = selectedShape else { return }
-    // editingView.textView.text = shape.text
+    editingView.textView.text = shape.text
     editingView.textView.font = shape.font
     editingView.textView.textColor = shape.fillColor
     editingView.bounds = shape.boundingRect


### PR DESCRIPTION
Text editing with >1 shape doesn't work because a key line has been commented out.